### PR TITLE
Feature/file permissions

### DIFF
--- a/.ccsync.yaml
+++ b/.ccsync.yaml
@@ -1,7 +1,7 @@
 # CC:Sync Configuration File
 # This file configures how CC:Sync copies files to your ComputerCraft computers
 
-version: "0.0.1"
+version: "1.0"
 
 # Where your source files are located (relative to this config file)
 sourceRoot: "./examples/test1"
@@ -22,9 +22,9 @@ computerGroups:
 rules:
   # Examples:
   # Sync to a specific computer:
-  - source: "*.lua" # File in your sourceRoot
-    target: "/lib" # Where to put it on the computer
-    computers: ["monitors"] # Computer IDs to sync to
+  - source: "a.lua" # File in your sourceRoot
+    target: "/" # Where to put it on the computer
+    computers: ["1"] # Computer IDs to sync to
   #
   # Sync to a group of computers:
   # - source: "lib/*.lua"      # Glob patterns supported

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,13 @@
+interface NodeError extends Error {
+  code?: string
+  stack?: string
+}
+
+/**
+ * Node.js errors includes properties such as 'code', but TypeScript's base Error type doesn't know about it. Can use this type guard t
+ * @param error
+ * @returns
+ */
+export const isNodeError = (error: unknown): error is NodeError => {
+  return error instanceof Error && "code" in error
+}


### PR DESCRIPTION
Improves file permission error handling and adds test

Not sure if Minecraft ever claims read/write access to a file on a computer that is being edited, i.e. we try to write to it and would get something like err EBUSY. Just in my manual testing, a file can be opened on the computer in edit mode, and CC: Sync can still write to it. When edit mode is closed and reopened the copied data is present.

BEGIN_COMMIT_OVERRIDE
fix(sync): add file permissions error handling and tests

refactor: improved node error handling with typescript

chore: update .ccsync.yaml (for testing)
END_COMMIT_OVERRIDE