### PR TITLE
Path normalization and validation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,7 @@ const SyncRuleSchema = z.object({
       z.string().min(1, "Group name cannot be empty"),
     ])
     .describe("Computer IDs or group names to sync files to"),
+  flatten: z.boolean().optional(),
 })
 
 const AdvancedOptionsSchema = z.object({

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,7 +96,6 @@ const SyncRuleSchema = z.object({
       ComputerIdSchema,
       z.string().min(1, "Group name cannot be empty"),
     ])
-    .optional()
     .describe("Computer IDs or group names to sync files to"),
 })
 
@@ -163,7 +162,7 @@ export const ConfigSchema = z
 
 export type Config = z.infer<typeof ConfigSchema>
 export type ComputerGroup = z.infer<typeof ComputerGroupSchema>
-export type FileSyncRule = z.infer<typeof SyncRuleSchema>
+export type SyncRule = z.infer<typeof SyncRuleSchema>
 
 // ---- CONFIG METHODS ----
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -201,7 +201,7 @@ export class SyncManager {
     for (const file of validation.resolvedFileRules) {
       const relativePath = path.relative(
         this.config.sourceRoot,
-        file.sourcePath
+        file.sourceAbsolutePath
       )
       fileResults.set(relativePath, [])
     }
@@ -245,7 +245,9 @@ export class SyncManager {
     // Display final status for each file
     for (const [filePath, results] of fileResults.entries()) {
       const file = validation.resolvedFileRules.find(
-        (f) => path.relative(this.config.sourceRoot, f.sourcePath) === filePath
+        (f) =>
+          path.relative(this.config.sourceRoot, f.sourceAbsolutePath) ===
+          filePath
       )
       if (!file) continue
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -18,6 +18,7 @@ import {
   validateFileSync,
   getFormattedDate,
   copyFilesToComputer,
+  normalizePath,
 } from "./utils"
 import { theme } from "./theme"
 import * as p from "@clack/prompts"
@@ -647,7 +648,9 @@ class WatchModeController {
     try {
       // If this is triggered by a file change, update the changedFiles set
       if (changedPath) {
-        const relativePath = path.relative(this.config.sourceRoot, changedPath)
+        const relativePath = normalizePath(
+          path.relative(this.config.sourceRoot, changedPath)
+        )
         this.changedFiles.add(relativePath)
         this.syncManager.invalidateCache()
         this.log.status(`File changed: ${changedPath}`)
@@ -743,9 +746,12 @@ class WatchModeController {
       const uniqueSourcePaths = new Set<string>()
 
       for (const rule of this.config.rules) {
-        const sourcePath = path.join(this.config.sourceRoot, rule.source)
+        const sourcePath = normalizePath(
+          path.join(this.config.sourceRoot, rule.source),
+          false // Don't strip trailing slash for globs
+        )
         const matches = await glob(sourcePath, { absolute: true })
-        matches.forEach((match) => uniqueSourcePaths.add(match))
+        matches.forEach((match) => uniqueSourcePaths.add(normalizePath(match)))
       }
 
       // Convert to array and store in watchedFiles

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export enum SyncMode {
  * A resolved file rule has been validated such that a file exists at the source path.
  */
 export interface ResolvedFileRule {
+  sourceAbsolutePath: string // Absolute path to source file
+  sourceRelativePath: string // Relative path to source file from source root
   sourcePath: string // Absolute path to source file
   targetPath: string // Relative path on computer
   computers: string[] // Resolved list of computer IDs (not group names)

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export enum SyncMode {
 export interface ResolvedFileRule {
   sourceAbsolutePath: string // Absolute path to source file
   sourceRelativePath: string // Relative path to source file from source root
-  sourcePath: string // Absolute path to source file
+  isRecursiveGlob: boolean // Whether source was **/ pattern
   targetPath: string // Relative path on computer
   computers: string[] // Resolved list of computer IDs (not group names)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,12 @@ export enum SyncMode {
   WATCH = "watch",
 }
 
-// Base interface for file sync configuration in .ccsync.yaml
-export interface SyncRule {
-  source: string // Glob pattern relative to sourceRoot
-  target: string // Target path on computer
-  computers?: string[] // Array of computer IDs or group names
-}
+// // Base interface for file sync configuration in .ccsync.yaml
+// export interface SyncRule {
+//   source: string // Glob pattern relative to sourceRoot
+//   target: string // Target path on computer
+//   computers?: string[] // Array of computer IDs or group names
+// }
 
 /**
  * Represents a viable file resolved from a config sync rule.

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export enum SyncMode {
 export interface ResolvedFileRule {
   sourceAbsolutePath: string // Absolute path to source file
   sourceRelativePath: string // Relative path to source file from source root
-  isRecursiveGlob: boolean // Whether source was **/ pattern
+  flatten?: boolean // Flatten if non-recursive or explicitly set
   targetPath: string // Relative path on computer
   computers: string[] // Resolved list of computer IDs (not group names)
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe, beforeEach, afterEach, mock } from "bun:test"
 import * as fs from "node:fs/promises"
 import path from "path"
-import { loadConfig } from "../src/config"
+import { loadConfig, withDefaultConfig } from "../src/config"
 import { SyncManager } from "../src/sync"
 import {
   TempCleaner,
@@ -10,10 +10,9 @@ import {
   createTestFiles,
   spyOnClackPrompts,
   createTestComputer,
-  withDefaultConfig,
 } from "./test-helpers"
 import { stringify } from "yaml"
-import { SyncEvent } from "../src/types"
+import { SyncEvent, type SyncResult } from "../src/types"
 
 describe("Integration: SyncManager", () => {
   let tempDir: string
@@ -128,11 +127,9 @@ describe("Integration: SyncManager", () => {
     if (!config) throw new Error("Failed to load config")
     const syncManager = new SyncManager(config)
 
+    const watchController = await syncManager.startWatchMode()
     try {
-      // eslint-disable-next-line no-async-promise-executor
-      return new Promise<void>(async (resolve, reject) => {
-        const watchController = await syncManager.startWatchMode()
-
+      await new Promise<void>((resolve, reject) => {
         // Track test phases
         let initialSyncCompleted = false
         let fileChangeDetected = false
@@ -231,166 +228,163 @@ describe("Integration: SyncManager", () => {
     }
   })
 
+  /**
+   * Tests complex file sync scenarios with multiple rules and glob patterns.
+   *
+   * Test validates:
+   * 1. Basic glob pattern syncing ("*.lua" -> "/" flattens files to root)
+   * 2. Directory-specific glob patterns ("programs/*.lua" -> "/" flattens from programs/ to root)
+   * 3. Directory preservation with target directories ("lib/*.lua" -> "/lib/" maintains utils.lua)
+   * 4. Directory structure preservation with recursive globs when flatten=false (** / *.lua -> /all/)
+   * 5. Multiple computers getting different sets of files based on rules
+   */
   test("handles multiple sync rules with complex patterns", async () => {
-    const configPath = path.join(tempDir, ".ccsync.yaml")
+    // Create base test files
+    await createTestFiles(sourceDir)
 
-    // Create additional test files
+    // Add test file in programs/ directory
     await fs.mkdir(path.join(sourceDir, "programs"), { recursive: true })
-    await fs.mkdir(path.join(sourceDir, "scripts"), { recursive: true })
     await fs.writeFile(
       path.join(sourceDir, "programs/main.lua"),
       "print('Main Program')"
     )
-    await fs.writeFile(
-      path.join(sourceDir, "programs/util.lua"),
-      "print('Utility')"
-    )
-    await fs.writeFile(
-      path.join(sourceDir, "scripts/startup.lua"),
-      "print('Custom Startup')"
-    )
 
+    const configPath = path.join(tempDir, ".ccsync.yaml")
     const configObject = withDefaultConfig({
       sourceRoot: sourceDir,
       minecraftSavePath: savePath,
       rules: [
-        // Rule 1: Copy all program files to root directory
+        // Computer 1: Root files to root directory (flattened)
+        { source: "*.lua", target: "/", computers: ["1"] },
+        // Computer 1: Programs files to root directory (flattened)
+        { source: "programs/*.lua", target: "/", computers: ["1"] },
+        // Computer 1: Root files to backup directory (flattened)
+        { source: "*.lua", target: "/backup/", computers: ["1"] },
+        // Computer 1: Programs files to backup directory (flattened)
+        { source: "programs/*.lua", target: "/backup/", computers: ["1"] },
+        // Both computers: lib files to lib directory
+        { source: "lib/*.lua", target: "/lib/", computers: ["1", "2"] },
+        // Computer 2: All files to /all/ preserving source directory structure
         {
-          source: "programs/*.lua",
-          target: "/",
-          computers: ["1"],
-        },
-        // Rule 2: Copy the same program files to a subdirectory
-        {
-          source: "programs/*.lua",
-          target: "/backup/",
-          computers: ["1"],
-        },
-        // Rule 3: Copy specific file to multiple locations
-        {
-          source: "scripts/startup.lua",
-          target: "/startup.lua",
-          computers: ["1"],
-        },
-        {
-          source: "scripts/startup.lua",
-          target: "/system/startup.lua",
-          computers: ["1"],
-        },
-        // Rule 4: Overlapping glob pattern
-        {
-          source: "**/*.lua",
+          source: "**/*.lua", // Matches all .lua files recursively
           target: "/all/",
           computers: ["2"],
+          flatten: false, // Preserve source structure relative to sourceRoot
         },
       ],
     })
 
-    const configContent = stringify(configObject)
-    await fs.writeFile(configPath, configContent)
-
-    // Create target computers
-    await createTestComputer(computersDir, "1", { createStartup: false })
-    await createTestComputer(computersDir, "2", { createStartup: false })
+    await fs.writeFile(configPath, stringify(configObject))
+    await Promise.all([
+      createTestComputer(computersDir, "1", { createStartup: false }),
+      createTestComputer(computersDir, "2", { createStartup: false }),
+    ])
 
     const { config } = await loadConfig(configPath)
     if (!config) throw new Error("Failed to load config")
+
     const syncManager = new SyncManager(config)
+    const manualController = await syncManager.startManualMode()
+    let syncCompleted = false
 
-    // Start manual mode and wait for sync
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise<void>(async (resolve, reject) => {
-      try {
-        const manualController = await syncManager.startManualMode()
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          manualController.off(SyncEvent.SYNC_COMPLETE, handleSyncComplete)
+          manualController.off(SyncEvent.SYNC_ERROR, handleSyncError)
+        }
 
-        manualController.on(
-          SyncEvent.SYNC_COMPLETE,
-          async ({ successCount, errorCount, missingCount }) => {
-            try {
-              // Verify sync statistics
-              expect(successCount).toBe(2) // Both computers synced
-              expect(errorCount).toBe(0)
-              expect(missingCount).toBe(0)
+        const handleSyncComplete = async ({
+          successCount,
+          errorCount,
+          missingCount,
+        }: SyncResult) => {
+          try {
+            // Verify sync statistics
+            expect(successCount).toBe(2) // Both computers processed
+            expect(errorCount).toBe(0) // No errors
+            expect(missingCount).toBe(0) // No missing computers
 
-              // Computer 1: Verify files in root directory
-              const computer1Dir = path.join(computersDir, "1")
-              expect(await fs.exists(path.join(computer1Dir, "main.lua"))).toBe(
-                true
-              )
-              expect(await fs.exists(path.join(computer1Dir, "util.lua"))).toBe(
-                true
-              )
+            // Verify both computers' file states
+            await Promise.all([
+              verifyComputer1Files(path.join(computersDir, "1")),
+              verifyComputer2Files(path.join(computersDir, "2")),
+            ])
 
-              // Computer 1: Verify files in backup directory
-              expect(
-                await fs.exists(path.join(computer1Dir, "backup", "main.lua"))
-              ).toBe(true)
-              expect(
-                await fs.exists(path.join(computer1Dir, "backup", "util.lua"))
-              ).toBe(true)
-
-              // Computer 1: Verify startup file in multiple locations
-              expect(
-                await fs.exists(path.join(computer1Dir, "startup.lua"))
-              ).toBe(true)
-              expect(
-                await fs.exists(
-                  path.join(computer1Dir, "system", "startup.lua")
-                )
-              ).toBe(true)
-
-              // Verify content is identical for duplicated files
-              const startupContent1 = await fs.readFile(
-                path.join(computer1Dir, "startup.lua"),
-                "utf8"
-              )
-              const startupContent2 = await fs.readFile(
-                path.join(computer1Dir, "system", "startup.lua"),
-                "utf8"
-              )
-              expect(startupContent1).toBe(startupContent2)
-              expect(startupContent1).toBe("print('Custom Startup')")
-
-              // Computer 2: Verify all Lua files are in all/ directory
-              const computer2Dir = path.join(computersDir, "2")
-              expect(
-                await fs.exists(path.join(computer2Dir, "all", "main.lua"))
-              ).toBe(true)
-              expect(
-                await fs.exists(path.join(computer2Dir, "all", "util.lua"))
-              ).toBe(true)
-              expect(
-                await fs.exists(path.join(computer2Dir, "all", "startup.lua"))
-              ).toBe(true)
-
-              // Computer 2: Verify files aren't in root
-              expect(await fs.exists(path.join(computer2Dir, "main.lua"))).toBe(
-                false
-              )
-              expect(
-                await fs.exists(path.join(computer2Dir, "startup.lua"))
-              ).toBe(false)
-
-              await manualController.stop()
-              await syncManager.stop()
-              resolve()
-            } catch (err) {
-              await syncManager.stop()
-              reject(err)
-            }
+            syncCompleted = true
+            cleanup()
+            resolve()
+          } catch (err) {
+            cleanup()
+            reject(err)
           }
-        )
+        }
 
-        manualController.on(SyncEvent.SYNC_ERROR, async (error) => {
-          await syncManager.stop()
+        const handleSyncError = (error: unknown) => {
+          cleanup()
           reject(error)
-        })
-      } catch (err) {
-        await syncManager.stop()
-        reject(err)
-      }
-    })
+        }
+
+        manualController.once(SyncEvent.SYNC_COMPLETE, handleSyncComplete)
+        manualController.once(SyncEvent.SYNC_ERROR, handleSyncError)
+      })
+
+      expect(syncCompleted).toBe(true)
+    } finally {
+      await manualController.stop()
+      await syncManager.stop()
+    }
   })
+
+  async function verifyComputer1Files(computer1Dir: string) {
+    // Check root level files
+    const rootFiles = await Promise.all([
+      fs.exists(path.join(computer1Dir, "program.lua")), // from root
+      fs.exists(path.join(computer1Dir, "startup.lua")), // from root
+      fs.exists(path.join(computer1Dir, "main.lua")), // from programs/
+      fs.exists(path.join(computer1Dir, "lib/utils.lua")), // from lib/
+    ])
+    rootFiles.forEach((exists) => expect(exists).toBe(true))
+
+    // Check backup directory
+    const backupFiles = await Promise.all([
+      fs.exists(path.join(computer1Dir, "backup/program.lua")), // from root
+      fs.exists(path.join(computer1Dir, "backup/startup.lua")), // from root
+      fs.exists(path.join(computer1Dir, "backup/main.lua")), // from programs/
+    ])
+    backupFiles.forEach((exists) => expect(exists).toBe(true))
+
+    // Verify content of one file to ensure proper copying
+    const content = await fs.readFile(
+      path.join(computer1Dir, "program.lua"),
+      "utf8"
+    )
+    expect(content).toBe("print('Hello')")
+  }
+
+  async function verifyComputer2Files(computer2Dir: string) {
+    // Verify lib files exist in root lib directory
+    await expect(
+      fs.exists(path.join(computer2Dir, "lib/utils.lua"))
+    ).resolves.toBe(true)
+
+    // Check all directory has files with preserved structure
+    const allDirFiles = await Promise.all([
+      fs.exists(path.join(computer2Dir, "all/program.lua")), // from root
+      fs.exists(path.join(computer2Dir, "all/startup.lua")), // fromt root
+      fs.exists(path.join(computer2Dir, "all/programs/main.lua")), // from programs/
+      fs.exists(path.join(computer2Dir, "all/lib/utils.lua")), // from lib/
+    ])
+    allDirFiles.forEach((exists) => expect(exists).toBe(true))
+
+    // Verify files don't exist in root (except lib)
+    const rootFiles = await Promise.all([
+      fs.exists(path.join(computer2Dir, "program.lua")),
+      fs.exists(path.join(computer2Dir, "startup.lua")),
+      fs.exists(path.join(computer2Dir, "main.lua")),
+    ])
+    rootFiles.forEach((exists) => expect(exists).toBe(false))
+  }
 
   test("handles glob pattern with multiple matching files in watch mode", async () => {
     const configPath = path.join(tempDir, ".ccsync.yaml")
@@ -421,12 +415,10 @@ describe("Integration: SyncManager", () => {
     const { config } = await loadConfig(configPath)
     if (!config) throw new Error("Failed to load config")
     const syncManager = new SyncManager(config)
+    const watchController = await syncManager.startWatchMode()
 
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise<void>(async (resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       try {
-        const watchController = await syncManager.startWatchMode()
-
         // Track test phases
         let initialSyncCompleted = false
         let fileChangeDetected = false
@@ -530,13 +522,13 @@ describe("Integration: SyncManager", () => {
         // Clean up timeout on success
         process.once("beforeExit", () => clearTimeout(timeout))
       } catch (err) {
-        await syncManager.stop()
         reject(err)
       }
     })
+    await syncManager.stop()
   })
 
-  test.skip("handles path edge cases in sync operation", async () => {
+  test("handles path edge cases in sync operation", async () => {
     const configPath = path.join(tempDir, ".ccsync.yaml")
 
     // Create test files with various path cases
@@ -625,11 +617,10 @@ describe("Integration: SyncManager", () => {
     if (!config) throw new Error("Failed to load config")
     const syncManager = new SyncManager(config)
 
-    try {
-      // eslint-disable-next-line no-async-promise-executor
-      return new Promise<void>(async (resolve, reject) => {
-        const manualController = await syncManager.startManualMode()
+    const manualController = await syncManager.startManualMode()
 
+    try {
+      await new Promise<void>((resolve, reject) => {
         manualController.on(
           SyncEvent.SYNC_COMPLETE,
           async ({ successCount, errorCount, missingCount }) => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -218,8 +218,8 @@ describe("Integration: SyncManager", () => {
         })
 
         // Set timeout for test
-        const timeout = setTimeout(() => {
-          syncManager.stop()
+        const timeout = setTimeout(async () => {
+          await syncManager.stop()
           reject(new Error("Test timeout - watch events not received"))
         }, 5000)
 
@@ -381,12 +381,12 @@ describe("Integration: SyncManager", () => {
           }
         )
 
-        manualController.on(SyncEvent.SYNC_ERROR, (error) => {
-          syncManager.stop()
+        manualController.on(SyncEvent.SYNC_ERROR, async (error) => {
+          await syncManager.stop()
           reject(error)
         })
       } catch (err) {
-        syncManager.stop()
+        await syncManager.stop()
         reject(err)
       }
     })
@@ -522,16 +522,217 @@ describe("Integration: SyncManager", () => {
         })
 
         // Set timeout for test
-        const timeout = setTimeout(() => {
-          syncManager.stop()
+        const timeout = setTimeout(async () => {
+          await syncManager.stop()
           reject(new Error("Test timeout - watch events not received"))
         }, 5000)
 
         // Clean up timeout on success
         process.once("beforeExit", () => clearTimeout(timeout))
       } catch (err) {
+        await syncManager.stop()
         reject(err)
       }
     })
+  })
+
+  test.skip("handles path edge cases in sync operation", async () => {
+    const configPath = path.join(tempDir, ".ccsync.yaml")
+
+    // Create test files with various path cases
+    await fs.mkdir(path.join(sourceDir, "folder with spaces"), {
+      recursive: true,
+    })
+    await fs.mkdir(path.join(sourceDir, "deep/nested/path"), {
+      recursive: true,
+    })
+    await fs.mkdir(path.join(sourceDir, "windows/style/path"), {
+      recursive: true,
+    })
+    await fs.mkdir(path.join(sourceDir, "mixed/style/path"), {
+      recursive: true,
+    })
+
+    // Create test files
+    const testFiles = [
+      {
+        path: "folder with spaces/test.lua",
+        content: "print('spaces')",
+      },
+      {
+        path: "deep/nested/path/deep.lua",
+        content: "print('deep')",
+      },
+      {
+        path: "windows/style/path/win.lua",
+        content: "print('windows')",
+      },
+      {
+        path: "mixed/style/path/mixed.lua",
+        content: "print('mixed')",
+      },
+    ]
+
+    // Create all test files
+    for (const file of testFiles) {
+      await fs.writeFile(path.join(sourceDir, file.path), file.content)
+    }
+
+    const configObject = withDefaultConfig({
+      sourceRoot: sourceDir,
+      minecraftSavePath: savePath,
+      rules: [
+        // Test spaces in paths
+        {
+          source: "folder with spaces/*.lua",
+          target: "/path with spaces/",
+          computers: ["1"],
+        },
+        // Test nested paths
+        {
+          source: "deep/nested/path/*.lua",
+          target: "/very/deep/nested/target/",
+          computers: ["1"],
+        },
+        // Test Windows-style target paths
+        {
+          source: "windows/style/path/*.lua",
+          target: "windows\\target\\folder\\", // Windows separators in target
+          computers: ["1"],
+        },
+        // Test mixed path styles in target
+        {
+          source: "mixed/style/path/*.lua",
+          target: "mixed\\style/target\\", // Mixed separators in target
+          computers: ["1"],
+        },
+        // Test all files with Windows-style target
+        {
+          source: "**/*.lua",
+          target: "backup\\all\\files\\", // Windows separators
+          computers: ["2"],
+        },
+      ],
+    })
+
+    await fs.writeFile(configPath, stringify(configObject))
+
+    // Create target computers
+    await createTestComputer(computersDir, "1", { createStartup: false })
+    await createTestComputer(computersDir, "2", { createStartup: false })
+
+    const { config } = await loadConfig(configPath)
+    if (!config) throw new Error("Failed to load config")
+    const syncManager = new SyncManager(config)
+
+    try {
+      // eslint-disable-next-line no-async-promise-executor
+      return new Promise<void>(async (resolve, reject) => {
+        const manualController = await syncManager.startManualMode()
+
+        manualController.on(
+          SyncEvent.SYNC_COMPLETE,
+          async ({ successCount, errorCount, missingCount }) => {
+            try {
+              expect(errorCount).toBe(0)
+              expect(missingCount).toBe(0)
+              expect(successCount).toBe(2)
+
+              const computer1Dir = path.join(computersDir, "1")
+
+              // Test each path case
+              const verifications = [
+                {
+                  desc: "spaces in path",
+                  path: path.join(computer1Dir, "path with spaces", "test.lua"),
+                  content: "print('spaces')",
+                },
+                {
+                  desc: "deep nested path",
+                  path: path.join(
+                    computer1Dir,
+                    "very",
+                    "deep",
+                    "nested",
+                    "target",
+                    "deep.lua"
+                  ),
+                  content: "print('deep')",
+                },
+                {
+                  desc: "Windows-style target path",
+                  path: path.join(
+                    computer1Dir,
+                    "windows",
+                    "target",
+                    "folder",
+                    "win.lua"
+                  ),
+                  content: "print('windows')",
+                },
+                {
+                  desc: "mixed style target path",
+                  path: path.join(
+                    computer1Dir,
+                    "mixed",
+                    "style",
+                    "target",
+                    "mixed.lua"
+                  ),
+                  content: "print('mixed')",
+                },
+              ]
+
+              // Verify each path and content
+              for (const verify of verifications) {
+                const exists = await fs.exists(verify.path)
+                if (!exists) {
+                  throw new Error(
+                    `Failed to handle ${verify.desc}: File not found at ${verify.path}`
+                  )
+                }
+
+                const content = await fs.readFile(verify.path, "utf8")
+                if (content !== verify.content) {
+                  throw new Error(`Content mismatch for ${verify.desc}`)
+                }
+              }
+
+              // Verify Computer 2's backup folder
+              const computer2Dir = path.join(computersDir, "2")
+              const backupDir = path.join(
+                computer2Dir,
+                "backup",
+                "all",
+                "files"
+              )
+
+              // All files should be in backup
+              for (const file of testFiles) {
+                const filename = path.basename(file.path)
+                const exists = await fs.exists(path.join(backupDir, filename))
+                if (!exists) {
+                  throw new Error(`Backup file not found: ${filename}`)
+                }
+              }
+
+              await manualController.stop()
+              await syncManager.stop()
+              resolve()
+            } catch (err) {
+              await syncManager.stop()
+              reject(err)
+            }
+          }
+        )
+
+        manualController.on(SyncEvent.SYNC_ERROR, async (error) => {
+          await syncManager.stop()
+          reject(error)
+        })
+      })
+    } finally {
+      await syncManager.stop()
+    }
   })
 })

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -6,7 +6,7 @@ import type { Computer, ResolvedFileRule } from "../src/types"
 import { getComputerShortPath, isRecursiveGlob } from "../src/utils"
 import * as p from "@clack/prompts"
 import { mock } from "bun:test"
-import { DEFAULT_CONFIG, type Config, type SyncRule } from "../src/config"
+import { type SyncRule } from "../src/config"
 
 /**
  * Creates a new tmp directory in the operating system's default directory for temporary files.
@@ -55,14 +55,6 @@ export async function createTestComputer(
   if (options.createStartup) {
     await writeFile(path.join(computerDir, "startup.lua"), "")
   }
-}
-
-/**
- * Returns a Config object merging the input config with a default
- * @param config
- */
-export const withDefaultConfig = (config: Partial<Config>): Config => {
-  return { ...DEFAULT_CONFIG, ...config }
 }
 
 /**
@@ -268,7 +260,7 @@ export function createResolvedFiles(
     createResolvedFile({
       sourceRoot,
       sourcePath: rule.source,
-      flatten: !isRecursiveGlob(rule.source) || rule.flatten || true,
+      flatten: !isRecursiveGlob(rule.source) || rule.flatten,
       targetPath: rule.target,
       computers: rule.computers,
     })

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -164,8 +164,16 @@ describe("Computer Discovery", () => {
 // ---- PATH HANDLING ----
 
 describe("Path Handling", () => {
-  test("normalizes Windows-style paths", () => {
+  test("normalizes paths correctly", () => {
     const tests = [
+      { input: "", expected: "" },
+      { input: ".", expected: "." },
+      { input: "..", expected: ".." },
+      { input: "./folder", expected: "folder" },
+      { input: "../folder", expected: "../folder" },
+      { input: "folder//subfolder", expected: "folder/subfolder" },
+      { input: "folder/./subfolder", expected: "folder/subfolder" },
+      { input: "folder/../sibling", expected: "sibling" },
       {
         input: "C:\\Users\\test\\file.txt",
         expected: "C:/Users/test/file.txt",

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../src/utils"
 import path from "path"
 import { mkdir, rm, writeFile } from "node:fs/promises"
-import { type Config } from "../src/config"
+import { withDefaultConfig, type Config } from "../src/config"
 import {
   createResolvedFile,
   createResolvedFiles,
@@ -21,7 +21,6 @@ import {
   createTestSave,
   createUniqueTempDir,
   TempCleaner,
-  withDefaultConfig,
 } from "./test-helpers"
 import { testLog } from "./setup"
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../src/utils"
 import path from "path"
 import { mkdir, rm, writeFile } from "node:fs/promises"
-import { withDefaultConfig, type Config } from "../src/config"
+import { type Config } from "../src/config"
 import {
   createResolvedFile,
   createResolvedFiles,
@@ -21,6 +21,7 @@ import {
   createTestSave,
   createUniqueTempDir,
   TempCleaner,
+  withDefaultConfig,
 } from "./test-helpers"
 import { testLog } from "./setup"
 
@@ -469,7 +470,6 @@ describe("File Operations", () => {
         const resolvedFile = createResolvedFile({
           sourceRoot: sourceDir,
           sourcePath: "program.lua",
-          isRecursiveGlob: false,
           targetPath: test.targetPath,
           computers: "1",
         })


### PR DESCRIPTION
Various improvements to path handling and attempts to be file system agnostic when it comes to path strings. At the minimum, this PR improves the handling of path separators and attempts to consistently use an appropriate system/OS path when interacting with the file system

Additionally, this PR improves glob pattern handling, especially when recursive globs, i.e. **/*, are used. A new **'flatten'** flag is added to the sync rules in the config (default is true). If false and a recursive pattern is used in 'source', the source directory structure will be maintained as the files are copied to the 'target' directory.

BEGIN_COMMIT_OVERRIDE
fix(general): improvements to path normalization, including better handling of unix vs windows paths. Internally, paths should consistently use a normalized path (forward slashes) and then convert to an appropriate system path when interacting with the filesystem or user-facing messages

fix(config)!: The 'computers' field in a SyncRule is no longer optional.

refactor: SyncRule type comes from config.ts, removed from types.ts. Update ResolvedFileRule type.

test: add createResolvedFile helpers in test-helper

test: utils.test.ts to use createResolvedFile(s)

feat!: A recursive */ glob pattern can now be used in config.rules.source in order to glob files and preserve the relative source directory structure when copied to a target directory. Adds a 'flatten' option to Sync Rules. Default is true. If set to false, will keep source directory structure when a recursive glob pattern is used

refactor: add isRecursiveGlob to ResolvedFileRule so that this flag can be checked when copying to know whether to keep directory structure or not

test: refactor test "handles multiple sync rules with complex patterns"

fix(config): improve withDefaultConfig helper and ensure that result from loadConfig is wrapped with this. Notably this ensures that flatten field is applied (default true) to all sync rules

fix: ensure consistent use of toSystemPath when logging/error messaging

test: add some additional path normalization tests
END_COMMIT_OVERRIDE