### PR TITLE
Feat/pino logging

### DIFF
--- a/.ccsync.yaml
+++ b/.ccsync.yaml
@@ -45,10 +45,10 @@ rules:
 advanced:
   # Enable logging to file
   logToFile: true
-  
+
   # Log level: silent, trace, debug, info, warn, error, fatal
   logLevel: "trace"
-  
+
   # How long to cache validation results (milliseconds)
   # Lower = more accurate but more CPU intensive, Higher = faster but may miss changes
   cache_ttl: 5000

--- a/.ccsync.yaml
+++ b/.ccsync.yaml
@@ -47,7 +47,7 @@ advanced:
   logToFile: true
   
   # Log level: silent, trace, debug, info, warn, error, fatal
-  logLevel: "debug"
+  logLevel: "trace"
   
   # How long to cache validation results (milliseconds)
   # Lower = more accurate but more CPU intensive, Higher = faster but may miss changes

--- a/.ccsync.yaml
+++ b/.ccsync.yaml
@@ -27,9 +27,9 @@ computerGroups:
 rules:
   # Examples:
   # Sync to a specific computer:
-  - source: "*" # File in your sourceRoot
+  - source: "*.lua" # File in your sourceRoot
     target: "/test" # Where to put it on the computer
-    computers: ["1"] # Computer IDs to sync to
+    computers: ["1", "2"] # Computer IDs to sync to
     # flatten: false
 
   # - source: "c.lua" # File in your sourceRoot

--- a/.ccsync.yaml
+++ b/.ccsync.yaml
@@ -1,6 +1,11 @@
 # CC:Sync Configuration File
 # This file configures how CC:Sync copies files to your ComputerCraft computers
 
+# IMPORTANT: Recommend using forward slashes (/) in paths, even on Windows.
+# Example: "C:/Users/name/path"
+# Otherwise, backslashes need to be properly escaped: "C:\Users\name\path"
+
+# Config version (do not modify)
 version: "2.0"
 
 # Where your source files are located (relative to this config file)
@@ -38,9 +43,12 @@ rules:
 
 # Advanced configuration options
 advanced:
-  # Enable verbose logging
-  verbose: true
-
+  # Enable logging to file
+  logToFile: true
+  
+  # Log level: silent, trace, debug, info, warn, error, fatal
+  logLevel: "debug"
+  
   # How long to cache validation results (milliseconds)
   # Lower = more accurate but more CPU intensive, Higher = faster but may miss changes
   cache_ttl: 5000

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ npx @bngarren/ccsync
 
 #### Basic Example
 ```yaml
+version: "2.0"
 sourceRoot: "./src"
 minecraftSavePath: "~/minecraft/saves/my_world"
 
@@ -263,12 +264,25 @@ The config for CC: Sync is a `.ccsync.yaml` file in your project root. If no fil
 |                   | The following fields are ***optional***:
 |                   |  - `flatten` (default true): Whether the matched source files should be flattened into the target directory. If a recursive glob pattern (e.g., **/*.lua) is used and `flatten` is false, the source directory structure will be preserved in the target directory.
 
+> Should use forward slashes (/) in paths, even on Windows:<br> 
+>`"C:/Users/name/path"`
+<br>
+> Otherwise, backslashes need to be properly escaped: `"C:\\Users\\name\\path"`
+
 ### Advanced Options
 These shouldn't need to be modified—mostly for debugging and performance.
 | Key               | Description                                                                                                     |
 |-------------------|-----------------------------------------------------------------------------------------------------------------|
-| `verbose`      | Enable detailed logging and error messages. |
+| `logToFile`      | Default: false. Enable logging to file.   |
+| `logLevel`      | Default: 'debug'. Options: 'silent', 'trace', 'debug', 'info', 'warn', 'error', 'fatal' |
 | `cache_ttl`      | Cache duration in milliseconds. This reduces how many times the source/target parameters must be validated on quick, repetitive re-syncs. |
+
+> Note: Log files are written to a log directory depending on the operating system:
+<br>
+> - Windows: `%USER%\AppData\Local\ccsync\logs`
+> - macOS: `~/Library/Logs/ccsync`
+> - Linux/Unix: `~/.local/share/ccsync/logs`
+
 
 ### Where is my Minecraft save?
 Below are some common places to look based on your operating system. However, if you use a custom launcher, then you will need to check where it stores the saves.

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "log-update": "^6.1.0",
         "picocolors": "^1.1.1",
         "pino": "^9.6.0",
+        "pino-roll": "^3.0.0",
         "strip-ansi": "^7.1.0",
         "ts-deepmerge": "^7.0.2",
         "yaml": "^2.7.0",
@@ -182,6 +183,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -488,6 +491,8 @@
     "pino": ["pino@9.6.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^4.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-roll": ["pino-roll@3.0.0", "", { "dependencies": { "date-fns": "^4.1.0", "sonic-boom": "^4.0.1" } }, "sha512-LF7eglhMVtnLqNYBtV8uFK05juEw8EtQtRG96TwNsMyKLv//8nKVaZoXY3/82s8sakY5ofGLmLuOPuVq08YWCQ=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "glob": "10.3.10",
         "log-update": "^6.1.0",
         "picocolors": "^1.1.1",
+        "pino": "^9.6.0",
         "strip-ansi": "^7.1.0",
         "ts-deepmerge": "^7.0.2",
         "yaml": "^2.7.0",
@@ -136,6 +137,8 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -259,6 +262,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
 
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
 
@@ -452,6 +457,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -478,11 +485,19 @@
 
     "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
+    "pino": ["pino@9.6.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^4.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.5.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw=="],
+
+    "process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
@@ -490,9 +505,13 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -515,6 +534,8 @@
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
@@ -541,6 +562,10 @@
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slice-ansi": ["slice-ansi@7.1.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg=="],
+
+    "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stable-hash": ["stable-hash@0.0.4", "", {}, "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g=="],
 
@@ -569,6 +594,8 @@
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "tapable": ["tapable@2.2.1", "", {}, "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="],
+
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "tinyglobby": ["tinyglobby@0.2.12", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "glob": "10.3.10",
     "log-update": "^6.1.0",
     "picocolors": "^1.1.1",
+    "pino": "^9.6.0",
     "strip-ansi": "^7.1.0",
     "ts-deepmerge": "^7.0.2",
     "yaml": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "log-update": "^6.1.0",
     "picocolors": "^1.1.1",
     "pino": "^9.6.0",
+    "pino-roll": "^3.0.0",
     "strip-ansi": "^7.1.0",
     "ts-deepmerge": "^7.0.2",
     "yaml": "^2.7.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { theme } from "./theme"
 import { toTildePath } from "./utils"
 import { type SyncMode } from "./types"
 import { AppError, ErrorSeverity, getErrorMessage } from "./errors"
+import { getLogFilePath, getLogger, initializeLogger } from "./log"
 
 const initConfig = async () => {
   // Find all config files
@@ -78,7 +79,7 @@ function getErrorCategoryTitle(category: ConfigErrorCategory) {
   }
 }
 
-const presentConfigErrors = (errors: ConfigError[], isVerbose: boolean) => {
+const presentConfigErrors = (errors: ConfigError[]) => {
   p.log.error("Configuration errors found:")
 
   // Group errors by category
@@ -108,7 +109,7 @@ const presentConfigErrors = (errors: ConfigError[], isVerbose: boolean) => {
         `  • ${error.message}${error.suggestion ? "\n    " + theme.dim(error.suggestion) : ""}`
       )
 
-      if (isVerbose && error.verboseDetail) {
+      if (error.verboseDetail) {
         p.log.info(`    ${theme.dim(error.verboseDetail)}`)
       }
     })
@@ -162,7 +163,7 @@ async function main() {
     const { config, errors } = await initConfig()
 
     if (errors.length > 0) {
-      presentConfigErrors(errors, config?.advanced?.verbose || false)
+      presentConfigErrors(errors)
       p.outro("Please fix these issues and try again.")
       process.exit(0)
     }
@@ -172,12 +173,25 @@ async function main() {
       process.exit(0)
     }
 
-    // console.debug(JSON.stringify(config, null, 2))
+    // Initialize logger with config settings
+    initializeLogger({
+      logToFile: config.advanced.logToFile,
+      logLevel: config.advanced.logLevel,
+    })
+
+    const log = getLogger()
+    log.debug("Configuration loaded successfully")
+    log.trace({ config }, "Current configuration")
+
+    if (config.advanced.logToFile) {
+      p.log.message(`Logging to file at: ${getLogFilePath()}`)
+    }
 
     const savePath = path.parse(config.minecraftSavePath)
 
     const gracefulExit = () => {
       p.outro(theme.info("Goodbye."))
+      log.info("Gracefully exited.")
       process.exit(0)
     }
 
@@ -197,6 +211,8 @@ async function main() {
       gracefulExit()
     }
 
+    log.debug(`User confirmed minecraftSavePath at ${config.minecraftSavePath}`)
+
     // Choose mode
     const mode: SyncMode = (await p.select({
       message: "Select sync mode:",
@@ -213,6 +229,8 @@ async function main() {
     if (p.isCancel(mode)) {
       gracefulExit()
     }
+
+    log.debug(`User selected sync mode: ${mode.toUpperCase()}`)
 
     const syncManager = new SyncManager(config)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,7 @@ async function main() {
       logLevel: config.advanced.logLevel,
     })
 
-    const log = getLogger()
+    const log = getLogger().child({ component: "Main" })
     log.debug("Configuration loaded successfully")
     log.trace({ config }, "Current configuration")
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,11 +181,23 @@ async function main() {
     })
 
     const log = getLogger().child({ component: "Main" })
-    log.debug("Configuration loaded successfully")
+    log.info(
+      {
+        version: process.env.npm_package_version || "unknown",
+        platform: process.platform,
+        nodeVersion: process.version,
+        config: {
+          sourceRoot: config.sourceRoot,
+          minecraftSave: path.posix.basename(config.minecraftSavePath),
+          rulesCount: config.rules.length,
+        },
+      },
+      "CC:Sync initialized"
+    )
     log.trace({ config }, "Current configuration")
 
     if (config.advanced.logToFile) {
-      p.log.message(`Logging to file at: ${getLogFilePath()}`)
+      p.log.message(color.dim(`Logging to file at: ${getLogFilePath()}`))
     }
 
     const savePath = path.parse(config.minecraftSavePath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,14 +137,15 @@ async function handleFatalError(
     error instanceof AppError ? error.message : getErrorMessage(error)
 
   // Log the error
-  p.log.error(`FATAL ERROR: ${message}`)
+  const log = getLogger()
+  log.fatal(`FATAL ERROR: ${message}`)
 
   // Try to clean up if we have a sync manager
   if (syncManager) {
     try {
       await syncManager.stop()
     } catch (stopErr) {
-      p.log.error(`Error during cleanup: ${getErrorMessage(stopErr)}`)
+      log.error(`Error during cleanup: ${getErrorMessage(stopErr)}`)
     }
   }
 
@@ -278,12 +279,7 @@ async function main() {
     }
   } catch (error) {
     // Catch-all for errors during startup
-    if (error instanceof AppError) {
-      await handleFatalError(error)
-    } else {
-      p.log.error(`Fatal error: ${getErrorMessage(error)}`)
-      process.exit(1)
-    }
+    await handleFatalError(error)
   }
 }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -43,7 +43,7 @@ export function getLogFilePath(): string {
   }
 
   // Use ISO date format for log files (YYYY-MM-DD)
-  const dateString = new Date().toISOString().split("T")[0]
+  const dateString = new Date().toLocaleDateString("en-CA")
   return path.join(logDir, `ccsync-${dateString}.log`)
 }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,29 +1,117 @@
-import { theme } from "./theme"
+import pino from "pino"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
 
-interface LogConfig {
-  verbose?: boolean
+// Define available log levels
+export type LogLevel =
+  | "silent"
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal"
+
+// Default log level
+const DEFAULT_LOG_LEVEL: LogLevel = "info"
+
+// Helper to get OS-specific user log directory
+export function getLogDirectory(): string {
+  const platform = process.platform
+  const homedir = os.homedir()
+
+  if (platform === "win32") {
+    // Windows: %USERPROFILE%\AppData\Local\ccsync\logs
+    return path.join(homedir, "AppData", "Local", "ccsync", "logs")
+  } else if (platform === "darwin") {
+    // macOS: ~/Library/Logs/ccsync
+    return path.join(homedir, "Library", "Logs", "ccsync")
+  } else {
+    // Linux/Unix: ~/.local/share/ccsync/logs
+    return path.join(homedir, ".local", "share", "ccsync", "logs")
+  }
 }
 
-export interface Logger {
-  verbose: (msg: string) => void
-  info: (msg: string) => void
-  step: (msg: string) => void
-  success: (msg: string) => void
-  warn: (msg: string) => void
-  error: (msg: string) => void
-  status: (msg: string) => void
+// Helper to get the log file path
+export function getLogFilePath(): string {
+  const logDir = getLogDirectory()
+
+  // Create the log directory if it doesn't exist
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true })
+  }
+
+  // Use ISO date format for log files (YYYY-MM-DD)
+  const dateString = new Date().toISOString().split("T")[0]
+  return path.join(logDir, `ccsync-${dateString}.log`)
 }
 
-export const createLogger = (config?: LogConfig): Logger => ({
-  verbose: (msg: string) => {
-    if (config?.verbose) {
-      console.log(theme.dim(msg))
-    }
-  },
-  info: (msg: string) => console.log(theme.info(msg)),
-  step: (msg: string) => console.log(theme.info(msg)),
-  success: (msg: string) => console.log(theme.success(`${msg}`)),
-  warn: (msg: string) => console.log(theme.warn(`${msg}`)),
-  error: (msg: string) => console.log(theme.error(`${msg}`)),
-  status: (msg: string) => console.log(theme.accent(msg)),
+// Logger instance that will be exported and used throughout the app
+let logger: pino.Logger = pino({
+  level: DEFAULT_LOG_LEVEL,
 })
+
+// Initialize logger with the given configuration
+export function initializeLogger(options: {
+  logToFile: boolean
+  logLevel: LogLevel
+}): pino.Logger {
+  if (!options.logToFile) {
+    // If logging to file is disabled, return a disabled logger
+    logger = pino({
+      level: "silent",
+      enabled: false,
+    })
+    return logger
+  }
+
+  // Setup file destination
+  const logFilePath = getLogFilePath()
+
+  // Create file stream
+  const destination = pino.destination({
+    dest: logFilePath,
+    sync: true, // Use sync writing to avoid losing logs on crashes
+  })
+
+  // Create the logger
+  logger = pino({
+    level: options.logLevel || DEFAULT_LOG_LEVEL,
+    timestamp: pino.stdTimeFunctions.isoTime,
+    transport: {
+      target: "pino/file",
+      options: { destination: logFilePath },
+    },
+  })
+
+  // Add process termination handlers to flush logs
+  process.on("beforeExit", () => {
+    logger.info("Application shutting down")
+    destination.flushSync()
+  })
+
+  process.on("uncaughtException", (err) => {
+    logger.fatal({ err }, "Uncaught exception")
+    destination.flushSync()
+  })
+
+  // Log initialization
+  logger.info(
+    {
+      logLevel: options.logLevel,
+      logFile: logFilePath,
+    },
+    "Logger initialized"
+  )
+
+  return logger
+}
+
+// Function to get the current logger instance
+export function getLogger(): pino.Logger {
+  return logger
+}
+
+// Export a default logger that other modules can use directly
+export default logger

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -907,9 +907,6 @@ class ManualModeController extends BaseController<ManualSyncEvents> {
 
   private setupKeyHandler(continueCallback: () => void): void {
     if (this.keyHandler) {
-      this.log.warn(
-        "manualController setupKeyHandler called while another was active"
-      )
       this.keyHandler.stop()
     }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -86,9 +86,14 @@ function getSyncPlanErrorMessage(syncPlan: SyncPlan): string {
 }
 
 export class SyncManager {
+  private _logger: pino.Logger | null = null
   private get log() {
-    return getLogger()
+    if (!this._logger) {
+      this._logger = getLogger().child({ component: "SyncManager" })
+    }
+    return this._logger
   }
+
   private ui: UI | null = null
   private activeModeController:
     | ManualModeController
@@ -746,8 +751,12 @@ export class SyncManager {
  * Base controller for common functionality between manual and watch modes
  */
 abstract class BaseController<T extends BaseControllerEvents> {
+  private _logger: pino.Logger | null = null
   protected get log() {
-    return getLogger()
+    if (!this._logger) {
+      this._logger = getLogger().child({ component: "Controller" })
+    }
+    return this._logger
   }
   protected events = createTypedEmitter<T>()
   protected keyHandler: KeyHandler | null = null

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -11,6 +11,7 @@ import {
 import boxen from "boxen"
 import { pluralize } from "./utils"
 import stripAnsi from "strip-ansi"
+import { getLogger } from "./log"
 
 const theme = {
   primary: chalk.hex("#61AFEF"), // Bright blue
@@ -100,6 +101,9 @@ interface UIState {
 const MIN_RENDER_INTERVAL = 50
 
 export class UI {
+  private get log() {
+    return getLogger()
+  }
   private state: UIState
   private timer: ReturnType<typeof setInterval> | null = null
   private isActive = false
@@ -150,12 +154,14 @@ export class UI {
     process.stdout.write("\x1B[1;1H\x1B[0J")
 
     // Show the persistent header
-    console.log(
+    process.stdout.write(
       theme.primary(
         `\nCC: Sync - ${theme.bold(this.state.mode.toUpperCase())} mode started at ${this.state.lastUpdated.toLocaleString()}`
-      )
+      ) +
+        "\n" +
+        theme.primary("─".repeat(process.stdout.columns || 80)) +
+        "\n"
     )
-    console.log(theme.primary("─".repeat(process.stdout.columns || 80)) + "\n")
 
     // Display history (if any) in plain text
     for (const pastOutput of this.state.syncHistory) {
@@ -197,6 +203,8 @@ export class UI {
         this.renderDynamicElements()
       }
     }, 100)
+
+    this.log.info("UI started.")
   }
 
   stop(): void {
@@ -214,6 +222,8 @@ export class UI {
     // Final clear of dynamic elements
     logUpdate.clear()
     logUpdate.done()
+
+    this.log.info("UI stopped.")
   }
 
   private updateState(update: Partial<UIState>): void {
@@ -262,10 +272,6 @@ export class UI {
     })
   }
 
-  /**
-   *
-   * In contrast to other UI methods, we don't _queue_ the UIState updates here, we peform them synchronously so that the calling code is assured it has a clean, expected state before beginning another sync operation.
-   */
   startSyncOperation(
     options: { clearMessages: boolean } = { clearMessages: true }
   ): void {
@@ -279,8 +285,7 @@ export class UI {
       updates.messages = []
     }
 
-    // Apply updates synchronously
-    this.state = { ...this.state, ...updates }
+    this.updateState({ ...updates })
   }
 
   // Complete an operation and log results
@@ -309,8 +314,20 @@ export class UI {
     // Store in history before logging
     this.addToHistory(currentOutput)
 
-    // Log the new output with colors
-    console.log(currentOutput)
+    // Write the new output with colors
+    process.stdout.write(
+      header +
+        "\n" +
+        computerResults +
+        "\n" +
+        messages +
+        "\n" +
+        theme.dim("─".repeat(process.stdout.columns || 80)) +
+        "\n"
+    )
+
+    this.log.debug(`UI received a 'completedOperation: ${result.toUpperCase()}`)
+
     // After logging static content, re-render dynamic elements
     this.renderDynamicElements()
     this.syncsComplete++

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -12,6 +12,7 @@ import boxen from "boxen"
 import { pluralize } from "./utils"
 import stripAnsi from "strip-ansi"
 import { getLogger } from "./log"
+import type { Logger } from "pino"
 
 const theme = {
   primary: chalk.hex("#61AFEF"), // Bright blue
@@ -101,8 +102,12 @@ interface UIState {
 const MIN_RENDER_INTERVAL = 50
 
 export class UI {
+  private _logger: Logger | null = null
   private get log() {
-    return getLogger()
+    if (!this._logger) {
+      this._logger = getLogger().child({ component: "UI" })
+    }
+    return this._logger
   }
   private state: UIState
   private timer: ReturnType<typeof setInterval> | null = null

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -697,11 +697,6 @@ export async function copyFilesToComputer(
   const skippedFiles = []
   const errors = []
 
-  // DEBUG
-  // console.log("\n=== Starting copyFilesToComputer ===")
-  // console.log("Computer path:", computerPath)
-  // console.log("Number of files to process:", resolvedFiles.length)
-
   // Normalize the computer path
   const normalizedComputerPath = normalizePath(computerPath)
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,21 +1,37 @@
 import { beforeAll, afterAll, mock } from "bun:test"
+import { initializeLogger } from "../src/log"
 
 // Store original console.log
 export const testLog = console.log
 
-mock.module("../src/log", () => ({
-  createLogger: () => ({
-    verbose: () => {},
-    info: () => {},
-    step: () => {},
-    success: () => {},
-    warn: () => {},
-    error: () => {},
-    status: () => {},
-  }),
-}))
-
 beforeAll(() => {
+  // Initialize logger with testing configuration - silent and not to file
+  initializeLogger({
+    logToFile: false,
+    logLevel: "silent",
+  })
+
+  // Mock the logger module for tests
+  mock.module("../src/logger", () => ({
+    default: {
+      trace: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    },
+    getLogger: () => ({
+      trace: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    }),
+    initializeLogger: () => {},
+  }))
+
   // Trying not to pollute the terminal output when running tests since our program utilizes lots of console and stdout output
   console.log = mock(() => {})
   console.clear = mock(() => {})

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -343,19 +343,20 @@ export function waitForEvent<T>(
 }
 
 /**
- * Mocks console.log to capture and store all UI output for later verification
+ * Mocks stdout.write to capture and store all UI output for later verification
  */
 export function captureUIOutput() {
   const output: string[] = []
-  const originalConsoleLog = console.log
+  const originalStdoutWrite = process.stdout.write
 
-  const mockConsoleLog = mock((...args: any[]) => {
+  const mockStdoutWrite = mock((...args: any[]) => {
     // Capture the output
     output.push(args.join(" "))
+    return true
   })
 
-  // Replace console.log
-  console.log = mockConsoleLog
+  // Replace stdout
+  process.stdout.write = mockStdoutWrite
 
   return {
     getOutput: () => [...output],
@@ -363,7 +364,7 @@ export function captureUIOutput() {
       output.length = 0
     },
     restore: () => {
-      console.log = originalConsoleLog
+      process.stdout.write = originalStdoutWrite
     },
   }
 }

--- a/watch-log.sh
+++ b/watch-log.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Define the log file path
+LOG_FILE="/Users/bngarren/Library/Logs/ccsync/current.log"
+
+# Check if the log file exists
+if [ ! -f "$LOG_FILE" ]; then
+    echo "Error: Log file does not exist: $LOG_FILE"
+    exit 1
+fi
+
+# Run the tail command and pipe it to pino-pretty
+echo "Tailing log file: $LOG_FILE"
+tail -f "$LOG_FILE" | pino-pretty -c -l -i pid,hostname,component -S -o '{if component} [{component}]: {end}{msg}'

--- a/watch-log.sh
+++ b/watch-log.sh
@@ -11,4 +11,4 @@ fi
 
 # Run the tail command and pipe it to pino-pretty
 echo "Tailing log file: $LOG_FILE"
-tail -f "$LOG_FILE" | pino-pretty -c -l -i pid,hostname,component -S -o '{if component} [{component}]: {end}{msg}'
+tail -f "$LOG_FILE" | pino-pretty -c -i pid,hostname,component -S -o '{if component} [{component}]: {end}{msg}'


### PR DESCRIPTION
add pino and pino-roll dependencies

breaking: update config to version 2.0 (given remove of "verbose" and addition of log options)

add logs throughout index, sync, and ui code. Included some performance measures in sync

update config.ts default config to include new log options

update readme

fix(ui): UI now uses process.stdout.write instead of console.log for terminal output

test: setup file now mocks our logger and so that program logs don't write during testing

chore: add watch-log.sh script to easily tail the log file with pino-pretty support